### PR TITLE
Bootstrap empty Cargo project

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Contributor Covenant Code of Conduct
+
+AgIsoStack-rs uses its [sibling project's code of
+conduct](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to AgIsoStack-rs
+
+We warmly welcome you to AgIsoStack-rs!
+
+Contributing to our open source repository implementing the ISOBUS (ISO11783) standard in the
+agricultural industry can involve anything from adding new features, improving existing code, fixing
+bugs, or even just helping to test and document the project. We greatly appreciate any contributions
+you can make to help drive progress and innovation in this field. Thank you for your interest and
+support!
+
+We accept all public contributions that adhere to the [code of
+conduct](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/main/CODE_OF_CONDUCT.md)
+defined by our sibling project
+[AgIsoStack++](https://github.com/Open-Agriculture/AgIsoStack-plus-plus). Additionally, for PR's we
+require the pass of all automated pre-merge checks, and a manual code review by a repository
+maintainer to ensure that our high code quality and project standards are maintained.
+
+## What are our guidelines?
+
+* Contributions must follow the usual `rustc` and `clippy` lints, and the default `rustfmt`
+  settings. Exceptions to lints are allowed, but should be defined in the project's `lib.rs` file
+
+  You can check these settings with `cargo check`, `cargo clippy`, and `cargo fmt`
+* The code should compile with no warnings in the CI pipeline using `RUSTFLAGS=-Dwarnings`
+* `rustdoc` documentation should compile without warnings in the CI pipeline using
+  `RUSTDOCFLAGS=-Dwarnings`
+* No code should be added under a more strict license than MIT, or which has not had conditions met
+  to be distributed under our license
+* There must be a copyright notice in every source file
+* Contributions must pass the CI pipeline
+* Aim for ~80% code coverage on new code, but prioritize high quality tests over gaming code
+  coverage percentages
+
+## Minimum supported Rust version
+
+**TODO:** Define a MSRV
+
+## Setting up a development environment
+
+## Copyright
+
+AgIsoStack-rs is sponsored by Raven Industries inc. as an open source project under the MIT license
+started during an Innovation Sprint under the condition that Raven maintains copyright over the
+project, including future contributions. See the [COPYRIGHT](./COPYRIGHT) file for details.
+
+In addition to the `COPYRIGHT` file, every source file should include the following copyright notice
+
+```rust
+// Copyright 2023 Raven Industries, inc.
+```

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,11 @@
+Copyright Ownership
+
+Contributing to this software is pursuant to the license agreement within
+GitHub available on GitHub’s website,
+https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#d-user-generated-content.
+
+This additional provision is meant to clarify, and not replace or alter the terms on GitHub’s terms
+of service. Contribution to the code within this content started by Raven Industries, Inc. and its
+affiliated companies (“Raven”) vests in Raven all copyrights in content, subject to the
+non-exclusive license granted by GitHub in the GitHub Terms and Conditions. By contributing to the
+code, You agree Raven owns the copyright in the code as stated in this provision.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ag-iso-stack"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "A Free ISO-11783 and J1939 CAN Stack"
+keywords = ["agriculture", "can", "canbus", "isobus", "j1939", "agritech", "smart-farming", "iso11783"]
+
+[dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Open-Agriculture
+Copyright (c) 2023 Raven Industries inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AgIsoStack-rs
+
+## About This Library
+
+AgIsoStack-rs is an MIT licensed hardware agnostic ISOBUS (ISO11783) and SAE J1939 CAN stack written in Rust.
+
+**This project is an experimental Work in Progress, and is not suitable for consumption.**
+
+## Compilation
+
+This library is built with Cargo
+
+```sh
+cargo build
+```
+
+## Tests
+
+Tests for this library are run with Cargo
+
+```sh
+cargo test
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
There's a team of engineers at Raven Industries that wanted to work on
an open sourced, MIT (or BSD) licensed Rust CAN stack for their
innovation sprint project. We got approval from Raven's leadership and
legal teams for doing so, under the provision that Raven maintains
copyright of the resulting project.

However, those same engineers believe the project will be most
successful long-term if we work together with the _excellent_
Open-Agriculture community, which seems especially true as the very same
community has expressed significant interest in such a CAN stack
[1,2,3,4] over the last few years. This belief is founded on the
momentum we have observed from the Open-Agriculture community, as well
as a believe in the values of contributing to open-source software.

See also the discussion in [5] for more context.

[1] https://github.com/Open-Agriculture/AgIsoStack-plus-plus/discussions/215
[2] https://github.com/Open-Agriculture/AgIsoStack-plus-plus/discussions/279
[3] https://github.com/Thom-de-Jong/AgIsoStack-rs
[4] https://github.com/OpenIsobus/OpenIsobus
[5] https://github.com/Open-Agriculture/AgIsoStack-rs/discussions/1

This PR:
* Sets up an empty Cargo project
* Adds README, CODE_OF_CONDUCT, and CONTRIBUTING files heavily influenced by their counterparts inhttps://github.com/Open-Agriculture/AgIsoStack-plus-plus
* Changes the copyright holder to [Raven Industries](https://www.ravenind.com/) as discussed in https://github.com/Open-Agriculture/AgIsoStack-rs/discussions/1
