### PR TITLE
Fix broken CI pipeline on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,11 @@ jobs:
               run: echo "pull_request_number=$(gh pr view --json number -q .number || echo "")" >> $GITHUB_OUTPUT
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - run: echo "Found PR number '${{ steps.pr.outputs.pull_request_number }}' with the github CLI"
 
-            - name: PR coverage report
+            - name: PR coverage report comment
               uses: 5monkeys/cobertura-action@v13
+              if: github.ref != 'refs/heads/main'
               with:
                   path: 'cobertura.xml'
                   repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The PR coverage report step uses a bot to add a comment on the PR associated with this commit. But for it to do so, it requires finding the PR number for the current branch. I found two ways to do so:

1. Change "on: [push]" to "on: [pull_request]" at the top-level workflow.
2. Use the "gh" CLI tool (which is installed by default in every default runs-on: distribution that GitHub provides) to find the PR number for the current branch

I picked option 2, because option 1 means that the workflow is only ever run on the creation of a PR, and not on every push to an existing PR.

But I didn't think about the pipeline that will run on the main branch after merging the PR, in which case there is no PR to submit a code-coverage comment on.

https://github.com/Open-Agriculture/AgIsoStack-rs/actions/runs/5790553309/job/15693817217