### PR TITLE
Add core address claiming logic

### DIFF
--- a/src/driver/can_id.rs
+++ b/src/driver/can_id.rs
@@ -286,7 +286,7 @@ mod tests {
             Address(0x0F),
             Priority::Six,
         );
-        assert!(matches!(encode_result, Err(_)));
+        assert!(encode_result.is_err());
 
         let error_contents: EncodingError = encode_result.unwrap_err();
         assert_eq!(error_contents.priority, Priority::Six);

--- a/src/network_management/can_message.rs
+++ b/src/network_management/can_message.rs
@@ -1,6 +1,4 @@
 // Copyright 2023 Raven Industries inc.
-#![allow(dead_code)]
-
 use super::name::NAME;
 use crate::driver::CanId;
 
@@ -19,5 +17,21 @@ impl CANMessage {
             source_name: NAME::default(),
             destination_name: NAME::default(),
         }
+    }
+
+    pub fn get_data(&self) -> &[u8] {
+        self.data.as_slice()
+    }
+
+    pub fn get_identifier(&self) -> CanId {
+        self.identifier
+    }
+
+    pub fn get_source_name(&self) -> NAME {
+        self.source_name
+    }
+
+    pub fn get_destination_name(&self) -> NAME {
+        self.destination_name
     }
 }

--- a/src/network_management/can_message.rs
+++ b/src/network_management/can_message.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 Raven Industries inc.
+#![allow(dead_code)]
+
+use super::name::NAME;
+use crate::driver::CanId;
+
+pub struct CANMessage {
+    data: Vec<u8>,
+    identifier: CanId,
+    source_name: NAME,
+    destination_name: NAME,
+}
+
+impl CANMessage {
+    pub(super) fn new(data: Vec<u8>, identifier: CanId) -> CANMessage {
+        CANMessage {
+            data,
+            identifier,
+            source_name: NAME::default(),
+            destination_name: NAME::default(),
+        }
+    }
+}

--- a/src/network_management/control_function.rs
+++ b/src/network_management/control_function.rs
@@ -31,6 +31,7 @@ pub enum AddressClaimingState {
 
 pub struct AddressClaimingData {
     state: AddressClaimingState,
+    name: NAME,
     timestamp: Option<Instant>,
     preferred_address: u8,
     random_delay: u8,
@@ -39,7 +40,6 @@ pub struct AddressClaimingData {
 
 pub enum ControlFunction {
     Internal {
-        name: NAME,
         address_claim_data: AddressClaimingData,
     },
     External {
@@ -48,9 +48,10 @@ pub enum ControlFunction {
 }
 
 impl AddressClaimingData {
-    pub fn new(preferred_address: u8, enabled: bool) -> AddressClaimingData {
+    pub fn new(name: NAME, preferred_address: u8, enabled: bool) -> AddressClaimingData {
         AddressClaimingData {
             state: AddressClaimingState::None,
+            name,
             timestamp: None,
             preferred_address,
             random_delay: AddressClaimingData::generate_random_delay(),
@@ -83,6 +84,17 @@ impl AddressClaimingData {
         self.state = new_state;
     }
 
+    pub fn get_name(&self) -> NAME {
+        self.name
+    }
+
+    pub fn set_name(&mut self, new_name: NAME) {
+        if self.name != new_name {
+            self.state = AddressClaimingState::None; // Name changed, state no longer valid
+        }
+        self.name = new_name;
+    }
+
     pub fn get_timestamp(&self) -> Option<Instant> {
         self.timestamp
     }
@@ -105,6 +117,7 @@ impl Default for AddressClaimingData {
     fn default() -> AddressClaimingData {
         AddressClaimingData {
             state: AddressClaimingState::None,
+            name: NAME::new(0),
             timestamp: None,
             preferred_address: 0xFE_u8,
             random_delay: AddressClaimingData::generate_random_delay(),

--- a/src/network_management/mod.rs
+++ b/src/network_management/mod.rs
@@ -1,4 +1,6 @@
 // Copyright 2023 Raven Industries inc.
+pub mod can_message;
 pub mod common_parameter_group_numbers;
 pub mod control_function;
 pub mod name;
+pub mod network_manager;

--- a/src/network_management/network_manager.rs
+++ b/src/network_management/network_manager.rs
@@ -1,229 +1,163 @@
 // Copyright 2023 Raven Industries inc.
-#![allow(dead_code)]
-#![allow(unused_variables)]
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use super::control_function::{AddressClaimingState, ControlFunction};
-use crate::driver::{CanId, Type};
+use crate::driver::{Address, CanId, Pgn, Priority};
 use crate::network_management::can_message::CANMessage;
 use crate::network_management::common_parameter_group_numbers::CommonParameterGroupNumbers;
 use crate::network_management::name::NAME;
 use std::collections::VecDeque;
 
+#[derive(Debug, Clone, Copy)]
+pub(super) enum MessageQueuePriority {
+    /// High priority messages are always sent to the driver before normal ones
+    High,
+    /// Normal messages are sent to the driver when no high priority messages are in the queue (todo)
+    Normal,
+}
+
 pub struct NetworkManager {
     control_function_table: [Option<ControlFunction>; 253],
-    channel: u8,
-    control_function_handle_counter: usize,
-    inactive_control_functions: Vec<ControlFunction>,
+    // Todo inactive_control_functions: Vec<ControlFunction>,
     address_claim_state_machines: Vec<ControlFunction>,
     high_priority_can_message_tx_queue: VecDeque<CANMessage>,
     normal_priority_can_message_tx_queue: VecDeque<CANMessage>,
 }
 
 impl NetworkManager {
-    pub fn new(channel: u8) -> Self {
+    pub fn new() -> Self {
         Self {
             control_function_table: std::array::from_fn(|_| None),
-            channel,
-            control_function_handle_counter: 0,
-            inactive_control_functions: Vec::new(),
+            // Todo inactive_control_functions: Vec::new(),
             address_claim_state_machines: Vec::new(),
             high_priority_can_message_tx_queue: VecDeque::new(),
             normal_priority_can_message_tx_queue: VecDeque::new(),
         }
     }
 
-    pub fn get_control_function_by_address(&self, address: usize) -> &Option<ControlFunction> {
-        &self.control_function_table[address]
+    pub fn get_control_function_by_address(&self, address: Address) -> &Option<ControlFunction> {
+        &self.control_function_table[address.0 as usize]
     }
 
-    fn send_raw_can_message(
-        &self,
-        source_address: u8,
-        destination_address: u8,
-        parameter_group_number: u32,
-        priority: u8,
-        data: &[u8],
-    ) -> bool {
-        false // Todo, link up with the driver layer
+    pub(super) fn get_next_free_arbitrary_address(&self) -> Address {
+        let default_external_cf = ControlFunction::External {
+            name: NAME::default(),
+        };
+        for address in 129..247 {
+            let is_device_at_address = self.get_control_function_by_address(Address(address));
+            let device_at_our_address = match is_device_at_address {
+                Some(_) => is_device_at_address.as_ref().unwrap(),
+                None => &default_external_cf,
+            };
+
+            let preferred_address_name: u64 = match device_at_our_address {
+                ControlFunction::External { name } => (*name).into(),
+                ControlFunction::Internal { address_claim_data } => {
+                    address_claim_data.get_name().into()
+                }
+            };
+
+            if <NAME as Into<u64>>::into(NAME::default()) == preferred_address_name {
+                return Address(address);
+            }
+        }
+        Address::NULL
     }
 
-    fn construct_request_for_address_claim() -> CANMessage {
-        const ADDRESS_CLAIM_REQUEST_LENGTH: usize = 3;
+    pub(super) fn construct_request_for_address_claim() -> CANMessage {
         let pgn_to_request: u32 = CommonParameterGroupNumbers::AddressClaim as u32;
-        let request = vec![
-            (pgn_to_request & 0xFF) as u8,
-            ((pgn_to_request >> 8) & 0xFF) as u8,
-            ((pgn_to_request >> 16) & 0xFF) as u8,
-        ];
-
-        let request_id = CanId::new(0, Type::Extended); // TODO Fix the ID once encoding method is available in CanId
-        CANMessage::new(request, request_id)
+        let request = pgn_to_request.to_le_bytes().to_vec();
+        let request_id = CanId::try_encode(
+            Pgn::from_raw(CommonParameterGroupNumbers::ParameterGroupNumberRequest as u32),
+            Address::NULL,
+            Address::BROADCAST,
+            Priority::Three,
+        );
+        CANMessage::new(request, request_id.unwrap())
     }
 
-    fn construct_address_claim(source_address: u8, name: u64) -> CANMessage {
-        let pgn: u32 = CommonParameterGroupNumbers::AddressClaim as u32;
-        let address_claim = vec![
-            (name & 0xFF) as u8,
-            ((name >> 8) & 0xFF) as u8,
-            ((name >> 16) & 0xFF) as u8,
-            ((name >> 24) & 0xFF) as u8,
-            ((name >> 32) & 0xFF) as u8,
-            ((name >> 40) & 0xFF) as u8,
-            ((name >> 48) & 0xFF) as u8,
-            ((name >> 56) & 0xFF) as u8,
-        ];
+    pub(super) fn construct_address_claim(source_address: Address, name: NAME) -> CANMessage {
+        let address_claim = <NAME as Into<u64>>::into(name).to_le_bytes().to_vec();
 
-        let request_id = CanId::new(0, Type::Extended); // TODO Fix the ID once encoding method is available in CanId
-        CANMessage::new(address_claim, request_id)
+        let request_id = CanId::try_encode(
+            Pgn::from_raw(CommonParameterGroupNumbers::AddressClaim as u32),
+            source_address,
+            Address::BROADCAST,
+            Priority::Default,
+        );
+        CANMessage::new(address_claim, request_id.unwrap())
+    }
+
+    pub(super) fn enqueue_can_message(
+        &mut self,
+        message: CANMessage,
+        queue_priority: MessageQueuePriority,
+    ) {
+        match queue_priority {
+            MessageQueuePriority::High => {
+                self.high_priority_can_message_tx_queue.push_back(message)
+            }
+            MessageQueuePriority::Normal => {
+                self.normal_priority_can_message_tx_queue.push_back(message)
+            }
+        }
     }
 
     fn update_address_claiming(&mut self) {
-        for address_claimer in &mut self.address_claim_state_machines {
+        let mut state_machines = std::mem::take(&mut self.address_claim_state_machines);
+        for address_claimer in &mut state_machines {
             match address_claimer {
                 ControlFunction::Internal { address_claim_data } => {
                     if address_claim_data.get_enabled() {
                         match address_claim_data.get_state() {
                             AddressClaimingState::None => {
-                                address_claim_data.set_state(AddressClaimingState::WaitForClaim);
+                                address_claim_data.set_state(
+                                    AddressClaimingState::update_state_none(address_claim_data),
+                                );
                             }
                             AddressClaimingState::WaitForClaim => {
                                 if address_claim_data.get_timestamp().is_none() {
                                     address_claim_data.set_timestamp(Some(Instant::now()))
                                 }
-                                if Instant::now()
-                                    .duration_since(address_claim_data.get_timestamp().unwrap())
-                                    > Duration::from_millis(
-                                        address_claim_data.get_random_delay() as u64
-                                    )
-                                {
-                                    address_claim_data
-                                        .set_state(AddressClaimingState::SendRequestForClaim);
-                                }
+
+                                address_claim_data.set_state(
+                                    AddressClaimingState::update_state_wait_for_claim(
+                                        address_claim_data,
+                                    ),
+                                );
                             }
                             AddressClaimingState::SendRequestForClaim => {
-                                self.high_priority_can_message_tx_queue.push_back(
-                                    NetworkManager::construct_request_for_address_claim(),
-                                );
                                 address_claim_data.set_state(
-                                    AddressClaimingState::WaitForRequestContentionPeriod,
+                                    AddressClaimingState::update_state_send_request_for_claim(self),
                                 );
                             }
                             AddressClaimingState::WaitForRequestContentionPeriod => {
-                                let contention_time_ms: u64 = 250;
-
-                                if Instant::now()
-                                    .duration_since(address_claim_data.get_timestamp().unwrap())
-                                    > Duration::from_millis(
-                                        address_claim_data.get_random_delay() as u64
-                                            + contention_time_ms,
-                                    )
-                                {
-                                    let device_at_our_address = self
-                                        .control_function_table
-                                        .get(address_claim_data.get_preferred_address() as usize);
-                                    let default_external_cf = ControlFunction::External {
-                                        name: NAME::default(),
-                                    };
-
-                                    let device_at_our_address = &device_at_our_address
-                                        .unwrap()
-                                        .as_ref()
-                                        .unwrap_or(&default_external_cf);
-                                    let preferred_address_name: u64 = match device_at_our_address {
-                                        ControlFunction::External { name } => {
-                                            <NAME as Into<u64>>::into(*name)
-                                        }
-                                        ControlFunction::Internal { address_claim_data } => {
-                                            address_claim_data.get_name().into()
-                                        }
-                                    };
-
-                                    if (!address_claim_data
-                                        .get_name()
-                                        .get_self_configurable_address()
-                                        && preferred_address_name
-                                            > address_claim_data.get_name().into())
-                                        || <NAME as Into<u64>>::into(NAME::default())
-                                            == preferred_address_name
-                                    {
-                                        // Either our preferred address is free, this is the best case, or:
-                                        // Our address is not free, but we cannot be at an arbitrary address, and the address can be stolen by us
-                                        address_claim_data.set_state(
-                                            AddressClaimingState::SendPreferredAddressClaim,
-                                        );
-                                    } else if !address_claim_data
-                                        .get_name()
-                                        .get_self_configurable_address()
-                                    {
-                                        // We cannot claim because we cannot tolerate an arbitrary address, and the CF at that spot wins due to its lower ISONAME
-                                        address_claim_data
-                                            .set_state(AddressClaimingState::UnableToClaim);
-                                    } else {
-                                        // We will move to another address if whoever is in our spot has a lower NAME
-                                        if preferred_address_name
-                                            < address_claim_data.get_name().into()
-                                        {
-                                            // We must scan the address space and move to a free address
-                                            address_claim_data.set_state(
-                                                AddressClaimingState::SendArbitraryAddressClaim,
-                                            );
-                                        } else {
-                                            // Our address claim wins because it's lower than the device that's in our preferred spot
-                                            address_claim_data.set_state(
-                                                AddressClaimingState::SendPreferredAddressClaim,
-                                            );
-                                        }
-                                    }
-                                }
+                                address_claim_data.set_state(
+                                    AddressClaimingState::update_state_wait_for_request_contention(
+                                        address_claim_data,
+                                        self,
+                                    ),
+                                );
                             }
                             AddressClaimingState::SendPreferredAddressClaim
                             | AddressClaimingState::SendReclaimAddressOnRequest
                             | AddressClaimingState::ContendForPreferredAddress => {
-                                self.high_priority_can_message_tx_queue.push_back(
-                                    NetworkManager::construct_address_claim(
-                                        address_claim_data.get_preferred_address(),
-                                        address_claim_data.get_name().into(),
+                                address_claim_data.set_state(
+                                    AddressClaimingState::update_state_send_preferred_address_claim(
+                                        address_claim_data,
+                                        self,
+                                    ),
+                                );
+                            }
+                            AddressClaimingState::SendArbitraryAddressClaim => {
+                                address_claim_data.set_state(
+                                    AddressClaimingState::update_state_send_arbitrary_address_claim(
+                                        address_claim_data,
+                                        self,
                                     ),
                                 );
                                 address_claim_data
-                                    .set_state(AddressClaimingState::AddressClaimingComplete);
-                            }
-                            AddressClaimingState::SendArbitraryAddressClaim => {
-                                let default_external_cf = ControlFunction::External {
-                                    name: NAME::default(),
-                                };
-                                for address in 129..247 {
-                                    let &device_at_our_address = &self.control_function_table
-                                        [address]
-                                        .as_ref()
-                                        .unwrap_or(&default_external_cf);
-
-                                    let preferred_address_name: u64 = match device_at_our_address {
-                                        ControlFunction::External { name } => {
-                                            <NAME as Into<u64>>::into(*name)
-                                        }
-                                        ControlFunction::Internal { address_claim_data } => {
-                                            address_claim_data.get_name().into()
-                                        }
-                                    };
-
-                                    if <NAME as Into<u64>>::into(NAME::default())
-                                        == preferred_address_name
-                                    {
-                                        // Found an address we can use
-                                        self.high_priority_can_message_tx_queue.push_back(
-                                            NetworkManager::construct_address_claim(
-                                                address as u8,
-                                                address_claim_data.get_name().into(),
-                                            ),
-                                        );
-                                        address_claim_data.set_state(
-                                            AddressClaimingState::AddressClaimingComplete,
-                                        );
-                                        break;
-                                    }
-                                }
+                                    .set_preferred_address(self.get_next_free_arbitrary_address());
                             }
                             AddressClaimingState::AddressClaimingComplete
                             | AddressClaimingState::UnableToClaim => {
@@ -235,9 +169,16 @@ impl NetworkManager {
                 _ => panic!("Only Internal CFs can perform address claiming"),
             }
         }
+        std::mem::swap(&mut state_machines, &mut self.address_claim_state_machines);
     }
 
     pub fn update(mut self) {
         self.update_address_claiming();
+    }
+}
+
+impl Default for NetworkManager {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/network_management/network_manager.rs
+++ b/src/network_management/network_manager.rs
@@ -6,7 +6,9 @@ use crate::driver::{Address, CanId, Pgn, Priority};
 use crate::network_management::can_message::CANMessage;
 use crate::network_management::common_parameter_group_numbers::CommonParameterGroupNumbers;
 use crate::network_management::name::NAME;
+use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::rc::Rc;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum MessageQueuePriority {
@@ -16,64 +18,84 @@ pub(super) enum MessageQueuePriority {
     Normal,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum CANTransmitState {
+    /// Used to describe that a CAN message was accepted by the CAN stack to be sent
+    Success,
+    /// Used to describe that a CAN message was not accepted by the stack and will not be sent
+    Fail,
+}
+
 pub struct NetworkManager {
-    control_function_table: [Option<ControlFunction>; 253],
-    // Todo inactive_control_functions: Vec<ControlFunction>,
-    address_claim_state_machines: Vec<ControlFunction>,
+    control_function_table: [Option<Rc<RefCell<ControlFunction>>>; 253],
+    inactive_control_functions: Vec<Rc<RefCell<ControlFunction>>>,
+    address_claim_state_machines: Vec<Rc<RefCell<ControlFunction>>>,
     high_priority_can_message_tx_queue: VecDeque<CANMessage>,
     normal_priority_can_message_tx_queue: VecDeque<CANMessage>,
+    receive_message_queue: VecDeque<CANMessage>,
 }
 
 impl NetworkManager {
     pub fn new() -> Self {
         Self {
             control_function_table: std::array::from_fn(|_| None),
-            // Todo inactive_control_functions: Vec::new(),
+            inactive_control_functions: Vec::new(),
             address_claim_state_machines: Vec::new(),
             high_priority_can_message_tx_queue: VecDeque::new(),
             normal_priority_can_message_tx_queue: VecDeque::new(),
+            receive_message_queue: VecDeque::new(),
         }
     }
 
-    pub fn get_control_function_by_address(&self, address: Address) -> &Option<ControlFunction> {
+    pub fn get_control_function_by_address(
+        &self,
+        address: Address,
+    ) -> &Option<Rc<RefCell<ControlFunction>>> {
         &self.control_function_table[address.0 as usize]
     }
 
-    pub(super) fn get_next_free_arbitrary_address(&self) -> Address {
-        let default_external_cf = ControlFunction::External {
-            name: NAME::default(),
-        };
-        for address in 129..247 {
-            let is_device_at_address = self.get_control_function_by_address(Address(address));
-            let device_at_our_address = match is_device_at_address {
-                Some(_) => is_device_at_address.as_ref().unwrap(),
-                None => &default_external_cf,
-            };
-
-            let preferred_address_name: u64 = match device_at_our_address {
-                ControlFunction::External { name } => (*name).into(),
-                ControlFunction::Internal { address_claim_data } => {
-                    address_claim_data.get_name().into()
+    pub fn get_control_function_address_by_name(&self, name: NAME) -> Address {
+        for (i, cf) in self.control_function_table.iter().enumerate() {
+            if let Some(extant_cf) = cf {
+                if extant_cf.borrow().get_name() == name {
+                    return Address(i as u8);
                 }
-            };
-
-            if <NAME as Into<u64>>::into(NAME::default()) == preferred_address_name {
-                return Address(address);
             }
         }
         Address::NULL
     }
 
-    pub(super) fn construct_request_for_address_claim() -> CANMessage {
-        let pgn_to_request: u32 = CommonParameterGroupNumbers::AddressClaim as u32;
-        let request = pgn_to_request.to_le_bytes().to_vec();
-        let request_id = CanId::try_encode(
-            Pgn::from_raw(CommonParameterGroupNumbers::ParameterGroupNumberRequest as u32),
-            Address::NULL,
-            Address::BROADCAST,
-            Priority::Three,
-        );
-        CANMessage::new(request, request_id.unwrap())
+    pub(super) fn on_new_internal_control_function(
+        &mut self,
+        new_cf: Rc<RefCell<ControlFunction>>,
+    ) {
+        self.inactive_control_functions.push(new_cf.clone());
+        self.address_claim_state_machines.push(new_cf);
+    }
+
+    pub(super) fn get_next_free_arbitrary_address(&self) -> Address {
+        for address in 129..247 {
+            let is_device_at_address = self.get_control_function_by_address(Address(address));
+            let is_valid_device: bool = is_device_at_address.is_some();
+
+            if !is_valid_device {
+                return Address(address);
+            } else {
+                let device_at_our_address = is_device_at_address.as_ref().unwrap().borrow();
+
+                let preferred_address_name: u64 = match &*device_at_our_address {
+                    ControlFunction::External { name } => (*name).into(),
+                    ControlFunction::Internal { address_claim_data } => {
+                        address_claim_data.get_name().into()
+                    }
+                };
+
+                if <NAME as Into<u64>>::into(NAME::default()) == preferred_address_name {
+                    return Address(address);
+                }
+            }
+        }
+        Address::NULL
     }
 
     pub(super) fn construct_address_claim(source_address: Address, name: NAME) -> CANMessage {
@@ -88,11 +110,24 @@ impl NetworkManager {
         CANMessage::new(address_claim, request_id.unwrap())
     }
 
+    pub(super) fn construct_request_for_address_claim() -> CANMessage {
+        let pgn_to_request: u32 = CommonParameterGroupNumbers::AddressClaim as u32;
+        let request = pgn_to_request.to_le_bytes().to_vec();
+        let request_id = CanId::try_encode(
+            Pgn::from_raw(CommonParameterGroupNumbers::ParameterGroupNumberRequest as u32),
+            Address::NULL,
+            Address::BROADCAST,
+            Priority::Three,
+        );
+        CANMessage::new(request, request_id.unwrap())
+    }
+
     pub(super) fn enqueue_can_message(
         &mut self,
         message: CANMessage,
         queue_priority: MessageQueuePriority,
     ) {
+        // Todo, max queue depth?
         match queue_priority {
             MessageQueuePriority::High => {
                 self.high_priority_can_message_tx_queue.push_back(message)
@@ -103,11 +138,48 @@ impl NetworkManager {
         }
     }
 
+    pub fn send_can_message(
+        &mut self,
+        parameter_group_number: Pgn,
+        data: &[u8],
+        source: Rc<RefCell<ControlFunction>>,
+        destination: Rc<RefCell<ControlFunction>>,
+        priority: Priority,
+    ) -> CANTransmitState {
+        if !data.is_empty() {
+            // Todo, handle lengths greater than 8
+
+            if data.len() <= 8 {
+                let source = source.borrow();
+                let destination = destination.borrow();
+                let message_id = CanId::try_encode(
+                    parameter_group_number,
+                    self.get_control_function_address_by_name(source.get_name()),
+                    self.get_control_function_address_by_name(destination.get_name()),
+                    priority,
+                )
+                .unwrap_or(CanId::default());
+
+                if message_id.raw() != CanId::default().raw() {
+                    self.enqueue_can_message(
+                        CANMessage::new(data.to_vec(), message_id),
+                        MessageQueuePriority::Normal,
+                    );
+                    return CANTransmitState::Success;
+                }
+            }
+        }
+        CANTransmitState::Fail
+    }
+
     fn update_address_claiming(&mut self) {
         let mut state_machines = std::mem::take(&mut self.address_claim_state_machines);
         for address_claimer in &mut state_machines {
-            match address_claimer {
-                ControlFunction::Internal { address_claim_data } => {
+            let mut address_claimer = address_claimer.borrow_mut();
+            match *address_claimer {
+                ControlFunction::Internal {
+                    ref mut address_claim_data,
+                } => {
                     if address_claim_data.get_enabled() {
                         match address_claim_data.get_state() {
                             AddressClaimingState::None => {
@@ -172,13 +244,120 @@ impl NetworkManager {
         std::mem::swap(&mut state_machines, &mut self.address_claim_state_machines);
     }
 
+    fn update_receive_messages(&mut self) {
+        while !self.receive_message_queue.is_empty() {
+            // Todo receive messages, need to generalize message handling
+            let current_message = self.receive_message_queue.front().unwrap();
+
+            // Process address claims and requests to claim
+            if NAME::default() == current_message.get_destination_name() {
+                // Broadcast Message
+                if current_message.get_identifier().pgn()
+                    == Pgn::from_raw(CommonParameterGroupNumbers::AddressClaim as u32)
+                {
+                    // Todo
+                } else if current_message.get_identifier().pgn()
+                    == Pgn::from_raw(
+                        CommonParameterGroupNumbers::ParameterGroupNumberRequest as u32,
+                    )
+                    && current_message.get_data().len() >= 3
+                {
+                    let message_data = current_message.get_data();
+                    let requested_pgn: u32 = (message_data[0] as u32)
+                        | ((message_data[1] as u32) << 8)
+                        | ((message_data[2] as u32) << 16);
+
+                    if requested_pgn
+                        == CommonParameterGroupNumbers::ParameterGroupNumberRequest as u32
+                    {
+                        for internal_cf in &mut self.address_claim_state_machines {
+                            let mut address_claimer = internal_cf.borrow_mut();
+                            match *address_claimer {
+                                ControlFunction::Internal {
+                                    ref mut address_claim_data,
+                                } => {
+                                    if address_claim_data.get_state()
+                                        == AddressClaimingState::AddressClaimingComplete
+                                    {
+                                        address_claim_data.set_state(
+                                            AddressClaimingState::SendReclaimAddressOnRequest,
+                                        );
+                                    }
+                                }
+                                ControlFunction::External { name: _ } => {}
+                            }
+                        }
+                    }
+                } else {
+                    // Destination specific
+                }
+
+                self.receive_message_queue.pop_front();
+            }
+        }
+    }
+
+    fn update_transmit_messages(&mut self) {
+        let should_continue_sending: bool = true; // Todo, check driver return values.
+
+        while !self.high_priority_can_message_tx_queue.is_empty() {
+            // todo hand off to driver
+            self.high_priority_can_message_tx_queue.pop_front();
+        }
+
+        while should_continue_sending && !self.normal_priority_can_message_tx_queue.is_empty() {
+            // todo hand off to driver
+            self.normal_priority_can_message_tx_queue.pop_front();
+        }
+    }
+
     pub fn update(mut self) {
+        self.update_receive_messages();
         self.update_address_claiming();
+        self.update_transmit_messages();
     }
 }
 
 impl Default for NetworkManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_creating_network_manager() {
+        let network = NetworkManager::new();
+        network.update();
+    }
+
+    #[test]
+    fn test_creating_internal_control_function() {
+        let mut network = NetworkManager::new();
+        let test_name = NAME::builder()
+            .device_class(0)
+            .device_class_instance(0)
+            .ecu_instance(0)
+            .function_code(130)
+            .function_instance(0)
+            .identity_number(123_u32)
+            .industry_group(2)
+            .function_instance(0)
+            .build();
+
+        let new_cf = ControlFunction::new_internal_control_function(
+            test_name,
+            Address(0x81),
+            true,
+            &mut network,
+        );
+
+        assert_eq!(
+            <NAME as Into<u64>>::into(new_cf.borrow().get_name()),
+            test_name.into()
+        );
     }
 }

--- a/src/network_management/network_manager.rs
+++ b/src/network_management/network_manager.rs
@@ -1,0 +1,243 @@
+// Copyright 2023 Raven Industries inc.
+#![allow(dead_code)]
+#![allow(unused_variables)]
+use std::time::{Duration, Instant};
+
+use super::control_function::{AddressClaimingState, ControlFunction};
+use crate::driver::{CanId, Type};
+use crate::network_management::can_message::CANMessage;
+use crate::network_management::common_parameter_group_numbers::CommonParameterGroupNumbers;
+use crate::network_management::name::NAME;
+use std::collections::VecDeque;
+
+pub struct NetworkManager {
+    control_function_table: [Option<ControlFunction>; 253],
+    channel: u8,
+    control_function_handle_counter: usize,
+    inactive_control_functions: Vec<ControlFunction>,
+    address_claim_state_machines: Vec<ControlFunction>,
+    high_priority_can_message_tx_queue: VecDeque<CANMessage>,
+    normal_priority_can_message_tx_queue: VecDeque<CANMessage>,
+}
+
+impl NetworkManager {
+    pub fn new(channel: u8) -> Self {
+        Self {
+            control_function_table: std::array::from_fn(|_| None),
+            channel,
+            control_function_handle_counter: 0,
+            inactive_control_functions: Vec::new(),
+            address_claim_state_machines: Vec::new(),
+            high_priority_can_message_tx_queue: VecDeque::new(),
+            normal_priority_can_message_tx_queue: VecDeque::new(),
+        }
+    }
+
+    pub fn get_control_function_by_address(&self, address: usize) -> &Option<ControlFunction> {
+        &self.control_function_table[address]
+    }
+
+    fn send_raw_can_message(
+        &self,
+        source_address: u8,
+        destination_address: u8,
+        parameter_group_number: u32,
+        priority: u8,
+        data: &[u8],
+    ) -> bool {
+        false // Todo, link up with the driver layer
+    }
+
+    fn construct_request_for_address_claim() -> CANMessage {
+        const ADDRESS_CLAIM_REQUEST_LENGTH: usize = 3;
+        let pgn_to_request: u32 = CommonParameterGroupNumbers::AddressClaim as u32;
+        let request = vec![
+            (pgn_to_request & 0xFF) as u8,
+            ((pgn_to_request >> 8) & 0xFF) as u8,
+            ((pgn_to_request >> 16) & 0xFF) as u8,
+        ];
+
+        let request_id = CanId::new(0, Type::Extended); // TODO Fix the ID once encoding method is available in CanId
+        CANMessage::new(request, request_id)
+    }
+
+    fn construct_address_claim(source_address: u8, name: u64) -> CANMessage {
+        let pgn: u32 = CommonParameterGroupNumbers::AddressClaim as u32;
+        let address_claim = vec![
+            (name & 0xFF) as u8,
+            ((name >> 8) & 0xFF) as u8,
+            ((name >> 16) & 0xFF) as u8,
+            ((name >> 24) & 0xFF) as u8,
+            ((name >> 32) & 0xFF) as u8,
+            ((name >> 40) & 0xFF) as u8,
+            ((name >> 48) & 0xFF) as u8,
+            ((name >> 56) & 0xFF) as u8,
+        ];
+
+        let request_id = CanId::new(0, Type::Extended); // TODO Fix the ID once encoding method is available in CanId
+        CANMessage::new(address_claim, request_id)
+    }
+
+    fn update_address_claiming(&mut self) {
+        for address_claimer in &mut self.address_claim_state_machines {
+            match address_claimer {
+                ControlFunction::Internal { address_claim_data } => {
+                    if address_claim_data.get_enabled() {
+                        match address_claim_data.get_state() {
+                            AddressClaimingState::None => {
+                                address_claim_data.set_state(AddressClaimingState::WaitForClaim);
+                            }
+                            AddressClaimingState::WaitForClaim => {
+                                if address_claim_data.get_timestamp().is_none() {
+                                    address_claim_data.set_timestamp(Some(Instant::now()))
+                                }
+                                if Instant::now()
+                                    .duration_since(address_claim_data.get_timestamp().unwrap())
+                                    > Duration::from_millis(
+                                        address_claim_data.get_random_delay() as u64
+                                    )
+                                {
+                                    address_claim_data
+                                        .set_state(AddressClaimingState::SendRequestForClaim);
+                                }
+                            }
+                            AddressClaimingState::SendRequestForClaim => {
+                                self.high_priority_can_message_tx_queue.push_back(
+                                    NetworkManager::construct_request_for_address_claim(),
+                                );
+                                address_claim_data.set_state(
+                                    AddressClaimingState::WaitForRequestContentionPeriod,
+                                );
+                            }
+                            AddressClaimingState::WaitForRequestContentionPeriod => {
+                                let contention_time_ms: u64 = 250;
+
+                                if Instant::now()
+                                    .duration_since(address_claim_data.get_timestamp().unwrap())
+                                    > Duration::from_millis(
+                                        address_claim_data.get_random_delay() as u64
+                                            + contention_time_ms,
+                                    )
+                                {
+                                    let device_at_our_address = self
+                                        .control_function_table
+                                        .get(address_claim_data.get_preferred_address() as usize);
+                                    let default_external_cf = ControlFunction::External {
+                                        name: NAME::default(),
+                                    };
+
+                                    let device_at_our_address = &device_at_our_address
+                                        .unwrap()
+                                        .as_ref()
+                                        .unwrap_or(&default_external_cf);
+                                    let preferred_address_name: u64 = match device_at_our_address {
+                                        ControlFunction::External { name } => {
+                                            <NAME as Into<u64>>::into(*name)
+                                        }
+                                        ControlFunction::Internal { address_claim_data } => {
+                                            address_claim_data.get_name().into()
+                                        }
+                                    };
+
+                                    if (!address_claim_data
+                                        .get_name()
+                                        .get_self_configurable_address()
+                                        && preferred_address_name
+                                            > address_claim_data.get_name().into())
+                                        || <NAME as Into<u64>>::into(NAME::default())
+                                            == preferred_address_name
+                                    {
+                                        // Either our preferred address is free, this is the best case, or:
+                                        // Our address is not free, but we cannot be at an arbitrary address, and the address can be stolen by us
+                                        address_claim_data.set_state(
+                                            AddressClaimingState::SendPreferredAddressClaim,
+                                        );
+                                    } else if !address_claim_data
+                                        .get_name()
+                                        .get_self_configurable_address()
+                                    {
+                                        // We cannot claim because we cannot tolerate an arbitrary address, and the CF at that spot wins due to its lower ISONAME
+                                        address_claim_data
+                                            .set_state(AddressClaimingState::UnableToClaim);
+                                    } else {
+                                        // We will move to another address if whoever is in our spot has a lower NAME
+                                        if preferred_address_name
+                                            < address_claim_data.get_name().into()
+                                        {
+                                            // We must scan the address space and move to a free address
+                                            address_claim_data.set_state(
+                                                AddressClaimingState::SendArbitraryAddressClaim,
+                                            );
+                                        } else {
+                                            // Our address claim wins because it's lower than the device that's in our preferred spot
+                                            address_claim_data.set_state(
+                                                AddressClaimingState::SendPreferredAddressClaim,
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            AddressClaimingState::SendPreferredAddressClaim
+                            | AddressClaimingState::SendReclaimAddressOnRequest
+                            | AddressClaimingState::ContendForPreferredAddress => {
+                                self.high_priority_can_message_tx_queue.push_back(
+                                    NetworkManager::construct_address_claim(
+                                        address_claim_data.get_preferred_address(),
+                                        address_claim_data.get_name().into(),
+                                    ),
+                                );
+                                address_claim_data
+                                    .set_state(AddressClaimingState::AddressClaimingComplete);
+                            }
+                            AddressClaimingState::SendArbitraryAddressClaim => {
+                                let default_external_cf = ControlFunction::External {
+                                    name: NAME::default(),
+                                };
+                                for address in 129..247 {
+                                    let &device_at_our_address = &self.control_function_table
+                                        [address]
+                                        .as_ref()
+                                        .unwrap_or(&default_external_cf);
+
+                                    let preferred_address_name: u64 = match device_at_our_address {
+                                        ControlFunction::External { name } => {
+                                            <NAME as Into<u64>>::into(*name)
+                                        }
+                                        ControlFunction::Internal { address_claim_data } => {
+                                            address_claim_data.get_name().into()
+                                        }
+                                    };
+
+                                    if <NAME as Into<u64>>::into(NAME::default())
+                                        == preferred_address_name
+                                    {
+                                        // Found an address we can use
+                                        self.high_priority_can_message_tx_queue.push_back(
+                                            NetworkManager::construct_address_claim(
+                                                address as u8,
+                                                address_claim_data.get_name().into(),
+                                            ),
+                                        );
+                                        address_claim_data.set_state(
+                                            AddressClaimingState::AddressClaimingComplete,
+                                        );
+                                        break;
+                                    }
+                                }
+                            }
+                            AddressClaimingState::AddressClaimingComplete
+                            | AddressClaimingState::UnableToClaim => {
+                                // Nothing to do
+                            }
+                        }
+                    }
+                }
+                _ => panic!("Only Internal CFs can perform address claiming"),
+            }
+        }
+    }
+
+    pub fn update(mut self) {
+        self.update_address_claiming();
+    }
+}


### PR DESCRIPTION
* Added the basic address claiming logic.
* Adds stub for CANMessage
* Adds stubs for some network manger functionality
* Needs still needs to be attached to the driver so it won't really do anything yet

Questions I have:

* Is there a more idomatic way to do a finite state machine than `match` ?
* Is there a setting we can adjust so the formatter doesn't make the entire state machine an unreadable blob of newlines?