### PR TITLE
Added an encode routine for a CanId

### DIFF
--- a/src/driver/address.rs
+++ b/src/driver/address.rs
@@ -5,7 +5,11 @@
 pub struct Address(pub u8);
 
 impl Address {
+    /// Address representing broadcasts for destination specific PGNs
     pub const GLOBAL: Address = Address(0xFF);
+    /// Alias for the global address
+    pub const BROADCAST: Address = Address(0xFF);
+    /// The null address is used by ECUs without an address such as during address claiming
     pub const NULL: Address = Address(0xFE);
 }
 


### PR DESCRIPTION
* Added a way to encode an extended CAN ID from its components. 
* Added an alias "BROADCAST" address which is the same as "GLOBAL". Internally at Raven we call it global but more broadly (and in AgIsoStack++) it seems to be called "broadcast".