### PR TITLE
Change tarpaulin coverage to use llvm engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: tarpaulin
-                  args: --release --all-features --out xml
+                  args: --release --all-features --engine llvm --out xml
                         
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2


### PR DESCRIPTION
The LVMM engine is considered being far more accurate in general.

Though there are a few nuances with using the LVMM engine: [source(tarpaulin repo)](https://github.com/xd009642/tarpaulin#nuances-with-llvm-coverage), but for our use case I think they are not as relevant, and hence the accuracy will outweigh the nuances