### PR TITLE
Fix objects that can have a NULL object id as attribute

### DIFF
--- a/src/network_management/network_manager.rs
+++ b/src/network_management/network_manager.rs
@@ -158,7 +158,7 @@ impl NetworkManager {
                     self.get_control_function_address_by_name(destination.get_name()),
                     priority,
                 )
-                .unwrap_or(CanId::default());
+                .unwrap_or_default();
 
                 if message_id.raw() != CanId::default().raw() {
                     self.enqueue_can_message(

--- a/src/object_pool/mod.rs
+++ b/src/object_pool/mod.rs
@@ -2,7 +2,7 @@ pub mod colour;
 pub mod reader;
 pub mod writer;
 
-mod object;
+pub mod object;
 mod object_attributes;
 mod object_id;
 mod object_pool;
@@ -19,4 +19,7 @@ pub use object_type::ObjectType;
 pub enum ParseError {
     DataEmpty,
     UnknownObjectType,
+    UnexpectedNullObjectId,
+    BooleanOutOfRange,
+    UnsupportedVtVersion,
 }

--- a/src/object_pool/mod.rs
+++ b/src/object_pool/mod.rs
@@ -12,6 +12,9 @@ mod vt_version;
 use crate::network_management::name::NAME;
 
 pub use colour::Colour;
+pub use object_attributes::ObjectRef;
+pub use object_id::NullableObjectId;
+pub use object_id::ObjectId;
 pub use object_pool::ObjectPool;
 pub use object_type::ObjectType;
 

--- a/src/object_pool/object.rs
+++ b/src/object_pool/object.rs
@@ -11,6 +11,8 @@ use crate::object_pool::object_attributes::{
 use crate::object_pool::object_id::ObjectId;
 use crate::object_pool::{Colour, ObjectType};
 
+use super::object_id::NullableObjectId;
+
 #[derive(Debug)]
 pub enum Object {
     WorkingSet(WorkingSet),
@@ -191,7 +193,7 @@ pub struct WorkingSet {
 pub struct DataMask {
     pub id: ObjectId,
     pub background_colour: u8,
-    pub soft_key_mask: ObjectId,
+    pub soft_key_mask: NullableObjectId,
     pub object_refs: Vec<ObjectRef>,
     pub macro_refs: Vec<MacroRef>,
 }
@@ -200,7 +202,7 @@ pub struct DataMask {
 pub struct AlarmMask {
     pub id: ObjectId,
     pub background_colour: u8,
-    pub soft_key_mask: ObjectId,
+    pub soft_key_mask: NullableObjectId,
     pub priority: u8,
     pub acoustic_signal: u8,
     pub object_refs: Vec<ObjectRef>,
@@ -253,7 +255,7 @@ pub struct InputBoolean {
     pub background_colour: u8,
     pub width: u16,
     pub foreground_colour: ObjectId,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: bool,
     pub enabled: bool,
     pub macro_refs: Vec<MacroRef>,
@@ -266,9 +268,9 @@ pub struct InputString {
     pub height: u16,
     pub background_colour: u8,
     pub font_attributes: ObjectId,
-    pub input_attributes: ObjectId,
+    pub input_attributes: NullableObjectId,
     pub options: InputStringOptions,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub justification: Alignment,
     pub value: String,
     pub enabled: bool,
@@ -283,7 +285,7 @@ pub struct InputNumber {
     pub background_colour: u8,
     pub font_attributes: ObjectId,
     pub options: NumberOptions,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u32,
     pub min_value: u32,
     pub max_value: u32,
@@ -301,10 +303,10 @@ pub struct InputList {
     pub id: ObjectId,
     pub width: u16,
     pub height: u16,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u8,
     pub options: InputListOptions,
-    pub list_items: Vec<ObjectId>,
+    pub list_items: Vec<NullableObjectId>,
     pub macro_refs: Vec<MacroRef>,
 }
 
@@ -316,7 +318,7 @@ pub struct OutputString {
     pub background_colour: u8,
     pub font_attributes: ObjectId,
     pub options: OutputStringOptions,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub justification: Alignment,
     pub value: String,
     pub macro_refs: Vec<MacroRef>,
@@ -330,7 +332,7 @@ pub struct OutputNumber {
     pub background_colour: u8,
     pub font_attributes: ObjectId,
     pub options: NumberOptions,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u32,
     pub offset: i32,
     pub scale: f32,
@@ -345,9 +347,9 @@ pub struct OutputList {
     pub id: ObjectId,
     pub width: u16,
     pub height: u16,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u8,
-    pub list_items: Vec<ObjectId>,
+    pub list_items: Vec<NullableObjectId>,
     pub macro_refs: Vec<MacroRef>,
 }
 
@@ -368,7 +370,7 @@ pub struct OutputRectangle {
     pub width: u16,
     pub height: u16,
     pub line_suppression: u8,
-    pub fill_attributes: ObjectId,
+    pub fill_attributes: NullableObjectId,
     pub macro_refs: Vec<MacroRef>,
 }
 
@@ -381,7 +383,7 @@ pub struct OutputEllipse {
     pub ellipse_type: u8,
     pub start_angle: u8,
     pub end_angle: u8,
-    pub fill_attributes: ObjectId,
+    pub fill_attributes: NullableObjectId,
     pub macro_refs: Vec<MacroRef>,
 }
 
@@ -391,7 +393,7 @@ pub struct OutputPolygon {
     pub width: u16,
     pub height: u16,
     pub line_attributes: ObjectId,
-    pub fill_attributes: ObjectId,
+    pub fill_attributes: NullableObjectId,
     pub polygon_type: u8,
     pub points: Vec<Point<u16>>,
     pub macro_refs: Vec<MacroRef>,
@@ -410,7 +412,7 @@ pub struct OutputMeter {
     pub end_angle: u8,
     pub min_value: u16,
     pub max_value: u16,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u16,
     pub macro_refs: Vec<MacroRef>,
 }
@@ -426,9 +428,9 @@ pub struct OutputLinearBarGraph {
     pub nr_of_ticks: u8,
     pub min_value: u16,
     pub max_value: u16,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u16,
-    pub target_value_variable_reference: ObjectId,
+    pub target_value_variable_reference: NullableObjectId,
     pub target_value: u16,
     pub macro_refs: Vec<MacroRef>,
 }
@@ -446,9 +448,9 @@ pub struct OutputArchedBarGraph {
     pub bar_graph_width: u16,
     pub min_value: u16,
     pub max_value: u16,
-    pub variable_reference: ObjectId,
+    pub variable_reference: NullableObjectId,
     pub value: u16,
-    pub target_value_variable_reference: ObjectId,
+    pub target_value_variable_reference: NullableObjectId,
     pub target_value: u16,
     pub macro_refs: Vec<MacroRef>,
 }
@@ -502,7 +504,7 @@ pub struct FillAttributes {
     pub id: ObjectId,
     pub fill_type: u8,
     pub fill_colour: u8,
-    pub fill_pattern: ObjectId,
+    pub fill_pattern: NullableObjectId,
     pub macro_refs: Vec<MacroRef>,
 }
 
@@ -561,7 +563,7 @@ pub struct ExtendedInputAttributes {
 #[derive(Debug)]
 pub struct ObjectPointer {
     pub id: ObjectId,
-    pub value: ObjectId,
+    pub value: NullableObjectId,
 }
 
 #[derive(Debug)]
@@ -630,9 +632,9 @@ pub struct GraphicsContext {
     pub graphics_cursor_y: i16,
     pub foreground_colour: u8,
     pub background_colour: u8,
-    pub font_attributes_object: ObjectId,
-    pub line_attributes_object: ObjectId,
-    pub fill_attributes_object: ObjectId,
+    pub font_attributes_object: NullableObjectId,
+    pub line_attributes_object: NullableObjectId,
+    pub fill_attributes_object: NullableObjectId,
     pub format: ColorFormat,
     pub options: GraphicsContextOptions,
     pub transparency_colour: u8,
@@ -646,9 +648,9 @@ pub struct WindowMask {
     pub background_colour: u8,
     pub options: WindowMaskOptions,
     pub name: ObjectId,
-    pub window_title: ObjectId,
-    pub window_icon: ObjectId,
-    pub objects: Vec<ObjectId>,
+    pub window_title: NullableObjectId,
+    pub window_icon: NullableObjectId,
+    pub objects: Vec<NullableObjectId>,
     pub object_refs: Vec<ObjectRef>,
     pub macro_refs: Vec<MacroRef>,
 }
@@ -658,7 +660,7 @@ pub struct KeyGroup {
     pub id: ObjectId,
     pub options: KeyGroupOptions,
     pub name: ObjectId,
-    pub key_group_icon: ObjectId,
+    pub key_group_icon: NullableObjectId,
     pub objects: Vec<ObjectId>,
     pub macro_refs: Vec<MacroRef>,
 }
@@ -674,7 +676,7 @@ pub struct ExternalObjectDefinition {
     pub id: ObjectId,
     pub options: ExternalObjectDefinitionOptions,
     pub name: NAME,
-    pub objects: Vec<ObjectId>,
+    pub objects: Vec<NullableObjectId>,
 }
 
 #[derive(Debug)]
@@ -687,9 +689,9 @@ pub struct ExternalReferenceName {
 #[derive(Debug)]
 pub struct ExternalObjectPointer {
     pub id: ObjectId,
-    pub default_object_id: ObjectId,
-    pub external_reference_name_id: ObjectId,
-    pub external_object_id: ObjectId,
+    pub default_object_id: NullableObjectId,
+    pub external_reference_name_id: NullableObjectId,
+    pub external_object_id: NullableObjectId,
 }
 
 #[derive(Debug)]
@@ -729,14 +731,14 @@ pub struct ScaledGraphic {
     pub height: u16,
     pub scale_type: u8,
     pub options: ScaledGraphicOptions,
-    pub value: u16,
+    pub value: NullableObjectId,
     pub macro_refs: Vec<MacroRef>,
 }
 
 #[derive(Debug)]
 pub struct WorkingSetSpecialControls {
     pub id: ObjectId,
-    pub id_of_colour_map: ObjectId,
-    pub id_of_colour_palette: ObjectId,
+    pub id_of_colour_map: NullableObjectId,
+    pub id_of_colour_palette: NullableObjectId,
     pub language_pairs: Vec<(String, String)>,
 }

--- a/src/object_pool/object_attributes.rs
+++ b/src/object_pool/object_attributes.rs
@@ -5,6 +5,8 @@ use bitvec::vec::BitVec;
 use bitvec::view::BitView;
 use strum_macros::FromRepr;
 
+use super::object_id::NullableObjectId;
+
 #[derive(FromRepr, Debug, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum WindowType {
@@ -168,9 +170,9 @@ impl core::ops::Add<Point<i16>> for Point<u16> {
 #[derive(Debug)]
 pub struct ObjectLabel {
     pub id: ObjectId,
-    pub string_variable_reference: ObjectId,
+    pub string_variable_reference: NullableObjectId,
     pub font_type: u8,
-    pub graphic_representation: ObjectId,
+    pub graphic_representation: NullableObjectId,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/object_pool/object_id.rs
+++ b/src/object_pool/object_id.rs
@@ -10,13 +10,14 @@ impl ObjectId {
 
     pub fn new(id: u16) -> Result<Self, ParseError> {
         if id == Self::NULL.id {
-            Err(ParseError::UnknownObjectType)
+            Err(ParseError::UnexpectedNullObjectId)
         } else {
             Ok(ObjectId { id })
         }
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NullableObjectId(Option<ObjectId>);
 
 impl NullableObjectId {

--- a/src/object_pool/object_id.rs
+++ b/src/object_pool/object_id.rs
@@ -18,7 +18,7 @@ impl ObjectId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NullableObjectId(Option<ObjectId>);
+pub struct NullableObjectId(pub Option<ObjectId>);
 
 impl NullableObjectId {
     pub const NULL: NullableObjectId = NullableObjectId(None);
@@ -72,6 +72,12 @@ impl TryFrom<u16> for ObjectId {
 
     fn try_from(id: u16) -> Result<Self, Self::Error> {
         ObjectId::new(id)
+    }
+}
+
+impl From<NullableObjectId> for Option<ObjectId> {
+    fn from(id: NullableObjectId) -> Self {
+        return id.0;
     }
 }
 

--- a/src/object_pool/object_pool.rs
+++ b/src/object_pool/object_pool.rs
@@ -79,15 +79,23 @@ impl ObjectPool {
     where
         I: IntoIterator<Item = u8>,
     {
+        let mut op = Self::new();
+        op.extend_with_iop(data);
+        op
+    }
+
+    pub fn extend_with_iop<I>(&mut self, data: I)
+    where
+        I: IntoIterator<Item = u8>,
+    {
         let mut data = data.into_iter();
 
-        let mut op = Self::new();
-
         while let Ok(o) = Object::read(&mut data) {
-            op.objects.push(o);
+            // By the standard, if there already is an object with the same ID, the new object
+            // replaces the old one
+            self.objects.retain(|x| x.id() != o.id());
+            self.objects.push(o);
         }
-
-        op
     }
 
     pub fn as_iop(&self) -> Vec<u8> {

--- a/src/object_pool/vt_version.rs
+++ b/src/object_pool/vt_version.rs
@@ -1,5 +1,5 @@
 use crate::object_pool::ParseError;
-use crate::object_pool::ParseError::UnknownObjectType;
+use crate::object_pool::ParseError::UnsupportedVtVersion;
 
 #[derive(Debug, Default)]
 pub enum VtVersion {
@@ -39,7 +39,7 @@ impl TryFrom<u8> for VtVersion {
             4 => Ok(VtVersion::Version4),
             5 => Ok(VtVersion::Version5),
             6 => Ok(VtVersion::Version6),
-            _ => Err(UnknownObjectType),
+            _ => Err(UnsupportedVtVersion),
         }
     }
 }

--- a/src/object_pool/writer.rs
+++ b/src/object_pool/writer.rs
@@ -1,3 +1,4 @@
+use super::object_id::NullableObjectId;
 use super::*;
 use crate::object_pool::colour::Colour;
 use crate::object_pool::object::{
@@ -84,11 +85,18 @@ impl Object {
         data
     }
 
-    fn write_objects(data: &mut Vec<u8>, objects: &Vec<ObjectId>) {
+    fn write_object_ids(data: &mut Vec<u8>, objects: &Vec<ObjectId>) {
         for d in objects {
             Self::write_u16(data, *d);
         }
     }
+
+    fn write_nullable_object_ids(data: &mut Vec<u8>, objects: &Vec<NullableObjectId>) {
+        for d in objects {
+            Self::write_u16(data, *d);
+        }
+    }
+
     fn write_object_refs(data: &mut Vec<u8>, object_refs: &Vec<ObjectRef>) {
         for d in object_refs {
             Self::write_u16(data, d.id);
@@ -247,7 +255,7 @@ impl Object {
         Self::write_u8(data, o.objects.len() as u8);
         Self::write_u8(data, o.macro_refs.len() as u8);
 
-        Self::write_objects(data, &o.objects);
+        Self::write_object_ids(data, &o.objects);
         Self::write_macro_refs(data, &o.macro_refs);
     }
     fn write_key(data: &mut Vec<u8>, o: &Key) {
@@ -339,7 +347,7 @@ impl Object {
         Self::write_u8(data, o.options);
         Self::write_u8(data, o.macro_refs.len() as u8);
 
-        Self::write_objects(data, &o.list_items);
+        Self::write_nullable_object_ids(data, &o.list_items);
         Self::write_macro_refs(data, &o.macro_refs);
     }
     fn write_output_string(data: &mut Vec<u8>, o: &OutputString) {
@@ -628,7 +636,7 @@ impl Object {
         Self::write_u8(data, o.object_refs.len() as u8);
         Self::write_u8(data, o.macro_refs.len() as u8);
 
-        Self::write_objects(data, &o.objects);
+        Self::write_nullable_object_ids(data, &o.objects);
         Self::write_object_refs(data, &o.object_refs);
         Self::write_macro_refs(data, &o.macro_refs);
     }
@@ -641,7 +649,7 @@ impl Object {
         Self::write_u8(data, o.objects.len() as u8);
         Self::write_u8(data, o.macro_refs.len() as u8);
 
-        Self::write_objects(data, &o.objects);
+        Self::write_object_ids(data, &o.objects);
         Self::write_macro_refs(data, &o.macro_refs);
     }
     fn write_graphics_context(data: &mut Vec<u8>, o: &GraphicsContext) {
@@ -675,7 +683,7 @@ impl Object {
         Self::write_u8(data, o.list_items.len() as u8);
         Self::write_u8(data, o.macro_refs.len() as u8);
 
-        Self::write_objects(data, &o.list_items);
+        Self::write_nullable_object_ids(data, &o.list_items);
         Self::write_macro_refs(data, &o.macro_refs);
     }
     fn write_extended_input_attributes(data: &mut Vec<u8>, o: &ExtendedInputAttributes) {
@@ -705,7 +713,7 @@ impl Object {
         Self::write_name(data, o.name);
         Self::write_u8(data, o.objects.len() as u8);
 
-        Self::write_objects(data, &o.objects);
+        Self::write_nullable_object_ids(data, &o.objects);
     }
     fn write_external_reference_name(data: &mut Vec<u8>, o: &ExternalReferenceName) {
         Self::write_u16(data, o.id);


### PR DESCRIPTION
There are attributes for some of the objects that are allowed to be the NULL object id. This PR wil fix working with pools that have those id's set to NULL.