### PR TITLE
Referenced objects and extendable object pool

### DIFF
--- a/src/object_pool/mod.rs
+++ b/src/object_pool/mod.rs
@@ -12,6 +12,9 @@ mod vt_version;
 use crate::network_management::name::NAME;
 
 pub use colour::Colour;
+pub use object_attributes::ObjectRef;
+pub use object_id::NullableObjectId;
+pub use object_id::ObjectId;
 pub use object_pool::ObjectPool;
 pub use object_type::ObjectType;
 

--- a/src/object_pool/object_pool.rs
+++ b/src/object_pool/object_pool.rs
@@ -79,15 +79,23 @@ impl ObjectPool {
     where
         I: IntoIterator<Item = u8>,
     {
+        let mut op = Self::new();
+        op.extend_with_iop(data);
+        op
+    }
+
+    pub fn extend_with_iop<I>(&mut self, data: I)
+    where
+        I: IntoIterator<Item = u8>,
+    {
         let mut data = data.into_iter();
 
-        let mut op = Self::new();
-
         while let Ok(o) = Object::read(&mut data) {
-            op.objects.push(o);
+            // By the standard, if there already is an object with the same ID, the new object
+            // replaces the old one
+            self.objects.retain(|x| x.id() != o.id());
+            self.objects.push(o);
         }
-
-        op
     }
 
     pub fn as_iop(&self) -> Vec<u8> {


### PR DESCRIPTION
- Added member function to get all the objects by id, that have been referenced by the object in question
- Added ability to extend an `ObjectPool` by another binary encoded object pool