### PR TITLE
Fix colour map not initializing

### DIFF
--- a/src/object_pool/mod.rs
+++ b/src/object_pool/mod.rs
@@ -3,7 +3,7 @@ pub mod reader;
 pub mod writer;
 
 pub mod object;
-mod object_attributes;
+pub mod object_attributes;
 mod object_id;
 mod object_pool;
 mod object_type;

--- a/src/object_pool/object_pool.rs
+++ b/src/object_pool/object_pool.rs
@@ -23,8 +23,8 @@ impl ObjectPool {
     pub fn new() -> Self {
         // Setup the default colour map
         let mut colour_map = [0xFFu8; 256];
-        for i in 0..(colour_map.len() as u8) {
-            colour_map[i as usize] = i;
+        for i in 0..colour_map.len() {
+            colour_map[i] = i as u8;
         }
 
         ObjectPool {


### PR DESCRIPTION
Due to casting 256 to u8 we ended up with 1. So this loop basically only ran once for index i=0, and the rest of the map didn't initialize correctly. This PR will fix that.